### PR TITLE
add ability to weave classes directory

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,7 @@ version := "0.4.5-SNAPSHOT"
 
 resolvers += "Typesafe Repo" at "http://repo.typesafe.com/typesafe/releases/"
 
-libraryDependencies += "org.aspectj" % "aspectjtools" % "1.6.11"
+libraryDependencies += "org.aspectj" % "aspectjtools" % "1.6.12"
 
 publishMavenStyle := false
 


### PR DESCRIPTION
Here example of use from my build.sbt

input - I don't want to weave all available jars, so there is only one in filter

<pre>
inputs in Aspectj <<= (fullClasspath in Compile, streams) map { (cp, s) => {
    val result = cp.map(_.data).filter(_.getName match {
      case "classes" => true
      case "digilib_2.8.2-0.0.1.jar" => true
      case skip => s.log.debug("aspectj skip entity: " + skip); false
    })
    result.foreach(e => s.log.debug("aspectj add entity: " + e))
    result
  }
}
</pre>


example AOP source files at
[https://github.com/ezh/android-component-DigiSSHD/tree/master/src/main/aspectj/org/digimead/digi/inetd/sshd](https://github.com/ezh/android-component-DigiSSHD/tree/master/src/main/aspectj/org/digimead/digi/inetd/sshd)

<pre>
aspectFilter in Aspectj := {
  (input, aspects) => {
    input.name match {
      case "classes" => aspects filter (_.toString.contains("/aspectj/org/digimead/digi/inetd/aop/"))
      case "digilib_2.8.2-0.0.1.jar" => aspects filter (_.toString.contains("/aspectj/org/digimead/digi/inetd/lib/aop/"))
      case file =>
       Seq.empty[File]
    }
  }
}
</pre>


patch positive sides:
- backward compatible
- weaving directories
- more than nothing

patch (all code?) negative sides:
- project **must** have AspectJ files with same content in difference classes for runtime and jar sources.
  If you try to use only one AspectJ for jar library and class directory there possible will be error. Android dex tool crashed with "class already exists" error. And, It is indeed. But nothing critical.

King regards,
Alexey
