### PR TITLE
update aspectj version to avoid conflicts on deployment

### DIFF
--- a/src/main/scala/com/typesafe/sbt/SbtAspectj.scala
+++ b/src/main/scala/com/typesafe/sbt/SbtAspectj.scala
@@ -56,7 +56,7 @@ object SbtAspectj extends Plugin {
   lazy val aspectjSettings: Seq[Setting[_]] = inConfig(Aspectj)(defaultAspectjSettings) ++ aspectjDependencySettings
 
   def defaultAspectjSettings = Seq(
-    aspectjVersion := "1.8.2",
+    aspectjVersion := "1.8.4",
     aspectjDirectory <<= crossTarget / "aspectj",
     showWeaveInfo := false,
     verbose := false,


### PR DESCRIPTION
Currently sbt-aspectj causes conflict problems with current aspectj version when you try to deploy project. 

I just upgraded version to the latest. 

Maybe it's not an issue since this project has nothing to do with deployment but I thought upgrading the version wouldn't hurt anyone.