### PR TITLE
Add artifactFilter to make sure the aspectjweaver JAR is returned

### DIFF
--- a/src/main/scala/com/typesafe/sbt/SbtAspectj.scala
+++ b/src/main/scala/com/typesafe/sbt/SbtAspectj.scala
@@ -221,7 +221,10 @@ object SbtAspectj extends Plugin {
     }
 
     def getWeaver = update map { report =>
-      report.matching(moduleFilter(organization = "org.aspectj", name = "aspectjweaver")).headOption
+      report.matching {
+        moduleFilter(organization = "org.aspectj", name = "aspectjweaver") &&
+        artifactFilter(`type` = "jar")
+      }.headOption
     }
 
     def createWeaverOptions = weaver map { weaver =>


### PR DESCRIPTION
Currently when trying to figure out the path to the `aspectjweaver` jar we only use a `moduleFilter` and rely on sbt's artifact ordering, i.e. the jar will always be at the head of the list. Using [coursier](https://github.com/coursier/coursier) for dependency resolution this is no longer valid since a POM is returned instead. This PR fixes it by adding an `artifactFilter` to make sure the returned file is a jar.