### PR TITLE
Update Aspectj

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ sbtPlugin := true
 organization := "com.lightbend.sbt"
 name := "sbt-aspectj"
 
-libraryDependencies += "org.aspectj" % "aspectjtools" % "1.8.10"
+libraryDependencies += "org.aspectj" % "aspectjtools" % "1.9.1"
 
 publishMavenStyle := false
 


### PR DESCRIPTION
The new version of AspectJ adds support for Java 9 and 10.

References
https://www.eclipse.org/aspectj/doc/released/README-191.html
https://www.eclipse.org/aspectj/doc/released/README-190.html