### PR TITLE
Bumped aspectj version to 1.9.6, apsectjSource to 1.9, sbt to 1.4.6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.idea/
 project/project/
 target/

--- a/README.md
+++ b/README.md
@@ -1,36 +1,89 @@
 sbt-aspectj
 ===========
 
-[sbt] plugin for weaving with [aspectj]. This plugin requires sbt 0.13.5+.
-
-[![Build Status](https://travis-ci.org/sbt/sbt-aspectj.png?branch=master)](https://travis-ci.org/sbt/sbt-aspectj)[ ![Download](https://api.bintray.com/packages/sbt/sbt-plugin-releases/sbt-aspectj/images/download.svg) ](https://bintray.com/sbt/sbt-plugin-releases/sbt-aspectj/_latestVersion)
-
+[sbt] plugin for weaving with [aspectj]. Forked from https://github.com/sbt/sbt-aspectj, this plugin supports aspectj 1.9.6.
 
 Add plugin
 ----------
 
 Add plugin to `project/plugins.sbt`. For example:
 
-    addSbtPlugin("com.lightbend.sbt" % "sbt-aspectj" % "{version}")
-
-See [released versions][releases].
-
-Note: earlier versions of sbt-aspectj used the `"com.typesafe.sbt"` organization.
+    addSbtPlugin("com.liyutech" % "sbt-aspectj" % "{version}")
 
 
-Sample projects
----------------
 
-There are [runnable sample projects][samples] included as sbt scripted tests.
+Example build.sbt:
+    
+```
+    import sbtassembly.MergeStrategy
+    import com.lightbend.sbt.SbtAspectj
+    import com.lightbend.sbt.SbtAspectj.autoImport.aspectjInputs
 
+    val Http4sVersion = "0.23.1"
+    val CirceVersion = "0.14.1"
+    val MunitVersion = "0.7.27"
+    val LogbackVersion = "1.2.5"
+    val MunitCatsEffectVersion = "1.0.5"
+    val QuillVersion = "3.10.0"
 
-Contribution policy
--------------------
+    val EntryPoint = Some("com.liyutech.iot.smarthome.SmartHomeMain")
 
-Contributions via GitHub pull requests are gladly accepted from their original
-author. Before we can accept pull requests, you will need to agree to the
-[Lightbend Contributor License Agreement][cla] online, using your GitHub account.
+    val root = (project in file("."))
+      .enablePlugins(SbtAspectj)
+      .settings(
+        organization := "com.liyutech.iot",
+        name := "smarthome",
+        version := "0.0.1-SNAPSHOT",
+        scalaVersion := "2.13.6",
+        libraryDependencies ++= Seq(
+          "org.http4s" %% "http4s-blaze-server" % Http4sVersion,
+          "org.http4s" %% "http4s-ember-server" % Http4sVersion,
+          "org.http4s" %% "http4s-ember-client" % Http4sVersion,
+          "org.http4s" %% "http4s-circe" % Http4sVersion,
+          "org.http4s" %% "http4s-dsl" % Http4sVersion,
+          "io.circe" %% "circe-generic" % CirceVersion,
+          "com.typesafe" % "config" % "1.4.1",
+          "co.fs2" %% "fs2-reactive-streams" % "3.1.5",
+          "org.typelevel" %% "cats-effect" % "3.2.3",
+          "javax.media" % "jmf" % "2.1.1e",
+          "org.aspectj" % "aspectjweaver" % "1.9.6",
+          "io.getquill" %% "quill-jdbc" % QuillVersion,
+          "io.getquill" %% "quill-jdbc-zio" % QuillVersion,
+          "io.getquill" %% "quill-jasync-postgres" % QuillVersion,
+          "io.getquill" %% "quill-async-postgres" % QuillVersion,
+          "com.h2database" % "h2" % "1.4.199",
+          "org.scalameta" %% "munit" % MunitVersion % Test,
+          "org.typelevel" %% "munit-cats-effect-3" % MunitCatsEffectVersion % Test,
+          "ch.qos.logback" % "logback-classic" % LogbackVersion,
+          "org.scalameta" %% "svm-subs" % "20.2.0",
+          "org.flywaydb" % "flyway-core" % "8.0.4"
+        ),
+        javacOptions ++= Seq("-source", "11", "-target", "11"),
+        assembly / mainClass := EntryPoint,
+        run / mainClass := EntryPoint,
+        reStart / mainClass := EntryPoint,
+        Compile / scalacOptions ~= {
+          _.filterNot(Set("-Werror", "-Xfatal-warnings"))
+        },
+        assemblyJarName := "smarthome.jar",
+        addCompilerPlugin("org.typelevel" %% "kind-projector" % "0.13.0" cross CrossVersion.full),
+        addCompilerPlugin("com.olegpy" %% "better-monadic-for" % "0.3.1"),
+        testFrameworks += new TestFramework("munit.Framework"),
+        assembly / assemblyMergeStrategy := {
+          case PathList(ps @ _*) if ps.last endsWith "io.netty.versions.properties" => MergeStrategy.first
+          case x =>
+            val oldStrategy = (assembly / assemblyMergeStrategy).value
+            oldStrategy(x)
+        },
 
+        // use the results of aspectj weaving
+        Aspectj/aspectjInputs += (Aspectj/aspectjCompiledClasses).value,
+        Compile/products := (Aspectj/products).value,
+        Runtime/products := (Compile/products).value,
+        Test/products := (Test/products).value,
+        Global / onChangedBuildSource := ReloadOnSourceChanges
+      )
+```
 
 License
 -------

--- a/build.sbt
+++ b/build.sbt
@@ -4,14 +4,14 @@ sbtPlugin := true
 organization := "com.liyutech"
 name := "sbt-aspectj"
 
-libraryDependencies += "org.aspectj" % "aspectjtools" % "1.9.6"
+libraryDependencies += "org.aspectj" % "aspectjtools" % "1.9.9.1"
 
 publishMavenStyle := true
 
 scriptedDependencies := publishLocal.value
-scriptedLaunchOpts ++= Seq("-Xms512m", "-Xmx512m", s"-Dproject.version=${version.value}")
+//scriptedLaunchOpts ++= Seq("-Xms512m", "-Xmx512m", s"-Dproject.version=${version.value}")
 
-crossSbtVersions := Vector("1.4.6", "1.1.5", "0.13.17")
+crossSbtVersions := Vector("1.6.2", "1.4.6", "1.1.5", "0.13.17")
 
 import ReleaseTransformations._
 releaseProcess := Seq[ReleaseStep](

--- a/build.sbt
+++ b/build.sbt
@@ -1,17 +1,12 @@
 
 sbtPlugin := true
 
-organization := "com.lightbend.sbt"
+organization := "com.liyutech"
 name := "sbt-aspectj"
 
 libraryDependencies += "org.aspectj" % "aspectjtools" % "1.9.6"
 
-publishMavenStyle := false
-
-bintrayOrganization := Some("sbt")
-bintrayRepository := "sbt-plugin-releases"
-bintrayPackage := name.value
-bintrayReleaseOnPublish := false
+publishMavenStyle := true
 
 scriptedDependencies := publishLocal.value
 scriptedLaunchOpts ++= Seq("-Xms512m", "-Xmx512m", s"-Dproject.version=${version.value}")
@@ -28,7 +23,6 @@ releaseProcess := Seq[ReleaseStep](
   commitReleaseVersion,
   tagRelease,
   releaseStepCommandAndRemaining("^ publish"),
-  releaseStepTask(bintrayRelease),
   setNextVersion,
   commitNextVersion,
   pushChanges

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ sbtPlugin := true
 organization := "com.lightbend.sbt"
 name := "sbt-aspectj"
 
-libraryDependencies += "org.aspectj" % "aspectjtools" % "1.8.10"
+libraryDependencies += "org.aspectj" % "aspectjtools" % "1.9.6"
 
 publishMavenStyle := false
 
@@ -16,7 +16,7 @@ bintrayReleaseOnPublish := false
 scriptedDependencies := publishLocal.value
 scriptedLaunchOpts ++= Seq("-Xms512m", "-Xmx512m", s"-Dproject.version=${version.value}")
 
-crossSbtVersions := Vector("1.1.5", "0.13.17")
+crossSbtVersions := Vector("1.4.6", "1.1.5", "0.13.17")
 
 import ReleaseTransformations._
 releaseProcess := Seq[ReleaseStep](

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.5
+sbt.version=1.6.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,2 @@
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.6")
-libraryDependencies += "org.scala-sbt" %% "scripted-plugin" % sbtVersion.value
+libraryDependencies += "org.scala-sbt" %% "scripted-plugin" % "1.7.0-M2-6810fix"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,2 @@
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.6")
-addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.1.2")
 libraryDependencies += "org.scala-sbt" %% "scripted-plugin" % sbtVersion.value

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,3 @@
-addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.1")
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.6")
-
+addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.1.2")
 libraryDependencies += "org.scala-sbt" %% "scripted-plugin" % sbtVersion.value

--- a/publish.sbt
+++ b/publish.sbt
@@ -24,7 +24,7 @@ ThisBuild / homepage := Some(url("https://github.com/haoqin/sbt-aspectj"))
 // Remove all additional repository other than Maven Central from POM
 ThisBuild / pomIncludeRepository := { _ => false }
 ThisBuild / publishTo := {
-  val nexus = "https://oss.sonatype.org/"
+  val nexus = "https://s01.oss.sonatype.org/"
   if (isSnapshot.value) Some("snapshots" at nexus + "content/repositories/snapshots")
   else Some("releases" at nexus + "service/local/staging/deploy/maven2")
 }

--- a/publish.sbt
+++ b/publish.sbt
@@ -17,7 +17,7 @@ ThisBuild / developers := List(
   )
 )
 
-ThisBuild / description := "sbt-aspectj that supports aspectj 1.9.6"
+ThisBuild / description := "sbt-aspectj that supports aspectj 1.9.9.1"
 ThisBuild / licenses := List("Apache 2" -> new URL("http://www.apache.org/licenses/LICENSE-2.0.txt"))
 ThisBuild / homepage := Some(url("https://github.com/haoqin/sbt-aspectj"))
 

--- a/publish.sbt
+++ b/publish.sbt
@@ -1,0 +1,31 @@
+ThisBuild / organization := "com.liyutech"
+ThisBuild / organizationName := "liyutech"
+ThisBuild / organizationHomepage := Some(url("https://github.com/haoqin/sbt-aspectj"))
+
+ThisBuild / scmInfo := Some(
+  ScmInfo(
+    url("https://github.com/haoqin/sbt-aspectj"),
+    "scm:git@github.com:haoqin/sbt-aspectj"
+  )
+)
+ThisBuild / developers := List(
+  Developer(
+    id    = "hqin",
+    name  = "liyutech",
+    email = "hqin@liyutech.com",
+    url   = url("https://github.com/haoqin/sbt-aspectj")
+  )
+)
+
+ThisBuild / description := "sbt-aspectj that supports aspectj 1.9.6"
+ThisBuild / licenses := List("Apache 2" -> new URL("http://www.apache.org/licenses/LICENSE-2.0.txt"))
+ThisBuild / homepage := Some(url("https://github.com/haoqin/sbt-aspectj"))
+
+// Remove all additional repository other than Maven Central from POM
+ThisBuild / pomIncludeRepository := { _ => false }
+ThisBuild / publishTo := {
+  val nexus = "https://oss.sonatype.org/"
+  if (isSnapshot.value) Some("snapshots" at nexus + "content/repositories/snapshots")
+  else Some("releases" at nexus + "service/local/staging/deploy/maven2")
+}
+ThisBuild / publishMavenStyle := true

--- a/src/main/scala/com/lightbend/sbt/SbtAspectj.scala
+++ b/src/main/scala/com/lightbend/sbt/SbtAspectj.scala
@@ -27,13 +27,13 @@ object SbtAspectj extends AutoPlugin {
   override def projectSettings: Seq[Def.Setting[_]] = aspectjSettings
 
   def defaultAspectjSettings = Seq(
-    aspectjVersion := "1.8.10",
+    aspectjVersion := "1.9.6",
     aspectjDirectory := crossTarget.value / "aspectj",
     aspectjShowWeaveInfo := false,
     aspectjVerbose := false,
     aspectjCompileOnly := false,
     aspectjOutXml := aspectjCompileOnly.value,
-    aspectjSourceLevel := "-1.5",
+    aspectjSourceLevel := "-1.9",
     aspectjLintProperties := Seq.empty,
     aspectjLintPropertiesFile := writeLintProperties.value,
     aspectjExtraOptions := Seq.empty,

--- a/src/main/scala/com/lightbend/sbt/SbtAspectj.scala
+++ b/src/main/scala/com/lightbend/sbt/SbtAspectj.scala
@@ -27,7 +27,7 @@ object SbtAspectj extends AutoPlugin {
   override def projectSettings: Seq[Def.Setting[_]] = aspectjSettings
 
   def defaultAspectjSettings = Seq(
-    aspectjVersion := "1.9.6",
+    aspectjVersion := "1.9.9.1",
     aspectjDirectory := crossTarget.value / "aspectj",
     aspectjShowWeaveInfo := false,
     aspectjVerbose := false,

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.11.1-SNAPSHOT"
+version in ThisBuild := "0.12.0"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.12.0"
+ThisBuild / version := "0.13.0"


### PR DESCRIPTION
The purpose of the PR is to make it easier for sbt projects to use aspectj 1.9.x that is compatible with Java 11. Tested it by publishing it to local repo using sbt publishLocal. Environment: macOS Big Sur version 11.2 using openjdk 11.0.9.1, Scala 2.12.12, and sbt 1.4.6.